### PR TITLE
Specify `engines`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,9 @@
     "@typescript-eslint/parser": "^4.29.2",
     "eslint": "^7.32.0",
     "typescript": "^4.3.5"
+  },
+  "engines": {
+    "node": "16.*",
+    "npm": "*"
   }
 }


### PR DESCRIPTION
Discord.js only supports node 16, so we should specify as such!